### PR TITLE
[ECO UI Tools] IssueBlueprintCommandToUnits

### DIFF
--- a/mods/EUT/modules/mexmanager.lua
+++ b/mods/EUT/modules/mexmanager.lua
@@ -79,12 +79,9 @@ local function UpgradeMexes(mexes, selector)
     end
 
     if not table.empty(upgrades) then
-        HiddenSelect(function()
-            for upgradesTo, upMexes in upgrades do
-                SelectUnits(upMexes)
-                IssueBlueprintCommand("UNITCOMMAND_Upgrade", upgradesTo, 1, false)
-            end
-        end)
+        for upgradesTo, upMexes in upgrades do
+            IssueBlueprintCommandToUnits(upMexes, "UNITCOMMAND_Upgrade", upgradesTo, 1, false)
+        end
     end
 end
 


### PR DESCRIPTION
Use this instead of function from "UI mod tools". Fixed bug when StartCommandMode in UMT's HiddenSelect() doesn't restore command mode to its pre-hiddenselection state. Idk why it happens but using global function from fa repo fixes the bug.