### PR TITLE
RFA : 1.1.0

### DIFF
--- a/mods/RFA/RFA.lua
+++ b/mods/RFA/RFA.lua
@@ -52,6 +52,11 @@ function Main(isReplay)
     local showRadar = false
     local showSonar = false
     local showCounterIntel = false
+    local ringOpacity = 255
+
+    options.ringOpacity:Bind(function(opt)
+        ringOpacity = opt()
+    end)
 
     options.showDirectFire:Bind(function(opt)
         showDirectFire = opt()
@@ -471,7 +476,7 @@ function Main(isReplay)
     ---@return number
     local function GetColorAndThickness(type)
         local params = overlayParams[type]
-        return ("ff%s"):format((params.NormalColor):sub(3)), params.Outer[1] / params.Type
+        return ("%02x%s"):format(ringOpacity, (params.NormalColor):sub(3)), params.Outer[1] / params.Type
     end
 
     local function TableClear(t)

--- a/mods/RFA/options.lua
+++ b/mods/RFA/options.lua
@@ -15,6 +15,7 @@ ReUI.Options.Mods["RFA"] = {
     showCounterIntel = Opt(true),
     showInMinimap = Opt(false),
     displayActualBuildRange = Opt(false),
+    ringOpacity = Opt(255),
 }
 
 function Main()
@@ -50,5 +51,6 @@ function Main()
                     "CONTROL"
                 },
                 options.buildPreviewKey),
+            Options.Slider("Ring opacity", 0, 255, 1, options.ringOpacity, 4),
         })
 end


### PR DESCRIPTION
* add rings opacity option

> There is an issue with rendering: some units have multiple weapons of same range causing blending of rings. In addition it also can have multiple similar weapons. That must be filtered too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable ring opacity control. Users can now adjust ring transparency through a new slider option in the Build Preview section with a range of 0-255 (default 255).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->