### PR TITLE
ReUI.Construciton: 1.1.0

### DIFF
--- a/mods/ReUI.Construction/Construction.lua
+++ b/mods/ReUI.Construction/Construction.lua
@@ -326,8 +326,40 @@ function Main(isReplay)
 
 
     ---@class Tab : ReUI.UI.Controls.CheckBox
+    ---@field _hitArea ReUI.UI.Controls.Group
     local Tab = ReUI.Core.Class(CheckBox)
     {
+        ---@param self Tab
+        ---@param parent ReUI.Construction.Panel
+        __init = function(self, parent)
+            CheckBox.__init(self, parent)
+            self._hitArea = Group(self)
+        end,
+
+        ---@param self Tab
+        ---@param layouter ReUI.UI.Layouter
+        InitLayout = function(self, layouter)
+            layouter(self._hitArea)
+                :Over(self)
+                :OffsetIn(self, 8, 7, 8, 9)
+                :EnableHitTest()
+
+            layouter(self)
+                :DisableHitTest()
+        end,
+
+        ---@param self Tab
+        Disable = function(self)
+            self._isDisabled = true
+            self:OnDisable()
+        end,
+
+        ---@param self Tab
+        Enable = function(self)
+            self._isDisabled = false
+            self:OnEnable()
+        end,
+
         ---@param self Tab
         HandleEvent = function(self, event)
             if event.Type == 'MouseEnter' then
@@ -461,19 +493,16 @@ function Main(isReplay)
                 :AtBottomIn(constructionPanel, -11)
 
             self._enhancementsTab:SetNewTextures(GetTabTextures(tabFiles.enhancement))
-            self._enhancementsTab:UseAlphaHitTest(true)
 
             layouter(self._selectionTab)
                 :Above(self._enhancementsTab, -16)
 
             self._selectionTab:SetNewTextures(GetTabTextures(tabFiles.selection))
-            self._selectionTab:UseAlphaHitTest(true)
 
             layouter(self._constructionTab)
                 :Above(self._selectionTab, -16)
 
             self._constructionTab:SetNewTextures(GetTabTextures(tabFiles.construction))
-            self._constructionTab:UseAlphaHitTest(true)
         end,
 
         ---@param self ConstructionTabs

--- a/mods/ReUI.Construction/Modules/Components/SelectedUnits.lua
+++ b/mods/ReUI.Construction/Modules/Components/SelectedUnits.lua
@@ -17,6 +17,11 @@ options.selection.showGroups:Bind(function(opt)
     showGroups = opt()
 end)
 
+local improvedDeselection
+options.selection.improvedDeselection:Bind(function(opt)
+    improvedDeselection = opt()
+end)
+
 ---@type table<TechCategory, integer>
 local techCatOrder = {
     ["TECH1"] = 1,
@@ -335,6 +340,30 @@ SelectedUnitsListHandler = ReUI.Core.Class(ASelectionHandler)
                         local selection = GetSelectedUnits()
                         local id = self.data.id
                         local excludedUnits = EntityCategoryFilterDown(categories[id], self.data.group.units)
+
+                        if improvedDeselection then
+                            local take = 0
+                            if event.Modifiers.Shift and event.Modifiers.Ctrl then
+                                take = 10
+                            elseif event.Modifiers.Shift then
+                                take = 1
+                            elseif event.Modifiers.Ctrl then
+                                take = 5
+                            end
+                            if take ~= 0 then
+                                local newExcludedUnits = {}
+                                local counter = 1
+                                for _, unit in excludedUnits do
+                                    table.insert(newExcludedUnits, unit)
+                                    if counter >= take then
+                                        break
+                                    end
+                                    counter = counter + 1
+                                end
+                                excludedUnits = newExcludedUnits
+                            end
+                        end
+
                         local units = {}
                         for _, unit in selection do
                             if not Contains(excludedUnits, unit) then

--- a/mods/ReUI.Construction/Options.lua
+++ b/mods/ReUI.Construction/Options.lua
@@ -10,8 +10,8 @@ ReUI.Options.Mods["ReUI.Construction"] = {
     width = Opt(400),
     canScroll = Opt(false),
     color = Opt("ffffffff"),
-
     selection = {
+        improvedDeselection = Opt(false),
         showGroups = Opt(false),
     },
 }
@@ -28,8 +28,8 @@ function Main()
         Options.Slider("Scale", 50, 300, 25, options.scale, 4),
         Options.Filter("Scroll through items", options.canScroll),
         Options.ColorSlider("Text color", options.color, 4),
-        -- Options.Title("Selection", nil, nil, UIUtil.factionTextColor),
-        -- Options.Filter("show groups", options.selection.showGroups, 4),
+        Options.Title("Selection", nil, nil, UIUtil.factionTextColor),
+        Options.Filter("Improved deselection", options.selection.improvedDeselection, 4),
     })
 
 end

--- a/mods/ReUI.Construction/mod_info.lua
+++ b/mods/ReUI.Construction/mod_info.lua
@@ -1,6 +1,6 @@
 name = "ReUI.Construction"
-uid = "ReUI.Construction-1.0.1"
-version = 2
+uid = "ReUI.Construction-1.1.0"
+version = 3
 copyright = ""
 description = [[Check on Github and official Discord server for mode details.
 https://github.com/4z0t/FAF-UI-Mods
@@ -14,4 +14,4 @@ enabled = true
 exclusive = false
 ui_only = true
 
-ReUI = 'ReUI.Construction=1.0.1'
+ReUI = 'ReUI.Construction=1.1.0'

--- a/mods/ReUI.Construction/mod_info.lua
+++ b/mods/ReUI.Construction/mod_info.lua
@@ -4,7 +4,7 @@ version = 3
 copyright = ""
 description = [[Check on Github and official Discord server for mode details.
 https://github.com/4z0t/FAF-UI-Mods
-https://discord.gg/UZeAEXHV
+https://discord.gg/EZb6h6gbWz
 ]]
 author = "4z0t"
 icon = "/mods/ReUI.Construction/icon.png"


### PR DESCRIPTION
New feature:
* add improved deselection as in base game

Fixes:
* dont use alpha hittest for construction tabs since it breaks on scale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved deselection: selective unit deselection with Shift/Ctrl/Shift+Ctrl modifiers.
  * Tabs now use an explicit hit area and support enable/disable states for more reliable interaction.

* **New Options**
  * Added "Improved deselection" toggle in Selection settings (off by default).

* **Chores**
  * Version bumped to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->