### PR TITLE
ReUI.Construction.Templates: 1.0.0

### DIFF
--- a/mods/ReUI.Construction.Templates/BuildTemplatePreview.lua
+++ b/mods/ReUI.Construction.Templates/BuildTemplatePreview.lua
@@ -1,0 +1,151 @@
+local Bitmap = ReUI.UI.Controls.Bitmap
+local Text = ReUI.UI.Controls.Text
+local CheckBox = ReUI.UI.Controls.CheckBox
+local Group = ReUI.UI.Controls.Group
+
+
+local UIUtil = import('/lua/ui/uiutil.lua')
+local Logic = import('/lua/ui/dialogs/createunit.logic.lua')
+
+local textures = {
+    land = '/textures/ui/common/icons/units/land_up.dds',
+    sea = '/textures/ui/common/icons/units/sea_up.dds',
+    amph = '/textures/ui/common/icons/units/amph_up.dds',
+    air = '/textures/ui/common/icons/units/air_up.dds',
+}
+
+
+---@param id string
+---@return FileName
+local function GetBackgroundImage(id)
+    return textures[Logic.GetLayerGroup(id)] or textures.land
+end
+
+---@param id string
+---@return FileName
+local function GetUnitImage(id)
+    local icon = UIUtil.UIFile('/icons/units/' .. id .. '_icon.dds', true)
+    return icon and DiskGetFileInfo(icon) and icon or
+        UIUtil.UIFile('/game/unit_view_icons/unidentified.dds')
+end
+
+local function GetUnitSkirtSizes(id)
+    local bp = __blueprints[id]
+    return bp.Physics.SkirtSizeX or bp.Footprint.SizeX or bp.SizeX or 1,
+        bp.Physics.SkirtSizeZ or bp.Footprint.SizeZ or bp.SizeZ or 1
+end
+
+local function GetSkirtCentreOffset(id)
+    local bp = __blueprints[id]
+    local w, h = bp.Footprint.SizeX or bp.SizeX or 1, bp.Footprint.SizeZ or bp.SizeZ or 1
+    local sW, sH = GetUnitSkirtSizes(id)
+    local XSkirtO, ZSkirtO = bp.Physics.SkirtOffsetX, bp.Physics.SkirtOffsetZ
+    return ((XSkirtO + ((sW + XSkirtO) - w))) / 2, ((ZSkirtO + ((sH + ZSkirtO) - h))) / 2
+end
+
+---@class BuildTemplatePreview.Icon : ReUI.UI.Controls.Bitmap
+---@field icon ReUI.UI.Controls.Bitmap
+---@field id string
+local Icon = ReUI.Core.Class(Bitmap)
+{
+    ---@param self BuildTemplatePreview.Icon
+    ---@param parent Control
+    ---@param id string
+    __init = function(self, parent, id)
+        Bitmap.__init(self, parent, GetBackgroundImage(id))
+        self.icon = Bitmap(self, GetUnitImage(id))
+    end,
+
+    ---@param self BuildTemplatePreview.Icon
+    ---@param layouter ReUI.UI.Layouter
+    InitLayout = function(self, layouter)
+        layouter(self.icon)
+            :Fill(self)
+    end
+}
+
+---@class BuildTemplatePreview : ReUI.UI.Controls.Group
+---@field _title ReUI.UI.Controls.Text
+---@field template any
+---@field xOffset number
+---@field zOffset number
+---@field icons BuildTemplatePreview.Icon[]
+BuildTemplatePreview = ReUI.Core.Class(Group)
+{
+    ---@param self BuildTemplatePreview
+    ---@param parent Control
+    ---@param template any
+    __init = function(self, parent, template)
+        Group.__init(self, parent)
+        self.template = template
+
+        self._title = Text(self)
+        self._title:SetFont("Arial", 16)
+        self._title:SetText(template.name)
+
+        local td = template.templateData
+        local xOffset, zOffset = { 0, 0 }, { 0, 0 }
+
+        for i = 3, table.getn(td) do
+            local id = td[i][1]
+            if __blueprints[id] then
+                local w, h = GetUnitSkirtSizes(id)
+                local posX, posZ = td[i][3], td[i][4]
+                local cOffX, cOffZ = GetSkirtCentreOffset(id)
+                xOffset[1] = math.min(xOffset[1], (posX - w / 2) + cOffX)
+                xOffset[2] = math.max(xOffset[2], (posX + w / 2) + cOffX)
+                zOffset[1] = math.min(zOffset[1], (posZ - h / 2) + cOffZ)
+                zOffset[2] = math.max(zOffset[2], (posZ + h / 2) + cOffZ)
+            end
+        end
+
+
+        self.xOffset, self.zOffset = (xOffset[1] + xOffset[2]) / 2, (zOffset[1] + zOffset[2]) / 2
+
+        self.icons = {}
+        for i = 3, table.getn(td) do
+            local id = td[i][1]
+            self.icons[i] = Icon(self, id)
+        end
+    end,
+
+    ---@param self BuildTemplatePreview
+    ---@param layouter ReUI.UI.Layouter
+    InitLayout = function(self, layouter)
+
+        layouter(self._title)
+            :Color(UIUtil.factionTextColor)
+            :DropShadow(true)
+            :AnchorToTop(self, 2)
+            :AtHorizontalCenterIn(self)
+
+        local td = self.template.templateData
+        local gridscale = 10
+        local tXgridSize = td[1]
+        local tZgridSize = td[2]
+        local tScale = 300 / (math.max(tXgridSize, tZgridSize) * gridscale)
+        local scale = gridscale * tScale
+
+        local xOffset, zOffset = self.xOffset, self.zOffset
+
+        for i = 3, table.getn(td) do
+            local id = td[i][1]
+            local icon = self.icons[i]
+            local w, h = GetUnitSkirtSizes(id)
+            local xCenOff, zCenOff = GetSkirtCentreOffset(id)
+
+            layouter(icon)
+                :Width(w * scale)
+                :Height(h * scale)
+                :AtCenterIn(self,
+                    (td[i][4] - zOffset + zCenOff) * scale,
+                    (td[i][3] - xOffset + xCenOff) * scale)
+        end
+
+        layouter(self)
+            :Width(300)
+            :Height(300)
+            :Depth(self:GetRootFrame():GetTopmostDepth() + 1)
+            :DisableHitTest(true)
+    end,
+}

--- a/mods/ReUI.Construction.Templates/FactoryTemplatePreview.lua
+++ b/mods/ReUI.Construction.Templates/FactoryTemplatePreview.lua
@@ -1,0 +1,128 @@
+local Bitmap = ReUI.UI.Controls.Bitmap
+local Text = ReUI.UI.Controls.Text
+local CheckBox = ReUI.UI.Controls.CheckBox
+local Group = ReUI.UI.Controls.Group
+
+local BaseGridPanel = ReUI.UI.Views.Grid.BaseGridPanel
+
+local MAX_COLUMNS = 10
+
+local UIUtil = import('/lua/ui/uiutil.lua')
+
+---@class FactoryTemplatePreview.Icon : ReUI.UI.Controls.Bitmap
+---@field count ReUI.UI.Controls.Text
+---@field id string
+local Icon = ReUI.Core.Class(Bitmap)
+{
+    ---@param self FactoryTemplatePreview.Icon
+    ---@param parent Control
+    __init = function(self, parent)
+        Bitmap.__init(self, parent)
+
+        self.count = Text(self)
+        self.count:SetFont("Arial", 20)
+    end,
+
+    ---@param self FactoryTemplatePreview.Icon
+    ---@param layouter ReUI.UI.Layouter
+    InitLayout = function(self, layouter)
+        layouter(self.count)
+            :Color "ffff00"
+            :DropShadow(true)
+            :AtRightBottomIn(self, 1, 1)
+            :DisableHitTest()
+    end,
+
+    ---@param self FactoryTemplatePreview.Icon
+    ---@param data {id: string, count: integer}
+    Set = function(self, data)
+        self:SetTexture(UIUtil.SkinnableFile('/icons/units/' .. data.id .. '_icon.dds'--[[@as FileName]] ))
+        self.count:SetText(data.count)
+    end,
+}
+
+---@class FactoryTemplatePreview : BaseGridPanel
+---@field _title ReUI.UI.Controls.Text
+FactoryTemplatePreview = ReUI.Core.Class(BaseGridPanel)
+{
+
+    ItemClass = Icon,
+
+    ---@param self FactoryTemplatePreview
+    ---@param parent Control
+    __init = function(self, parent)
+        BaseGridPanel.__init(self, parent)
+
+
+        self._title = Text(self)
+        self._title:SetFont("Arial", 16)
+
+        self.Rows = 1
+        self.Columns = 1
+
+        self.ColumnWidth = 48
+        self.RowHeight = 48
+
+        self.HorizontalSpacing = 2
+        self.VerticalSpacing = 2
+    end,
+
+    ---@param self FactoryTemplatePreview
+    ---@param item FactoryTemplatePreview.Icon
+    ---@param row number
+    ---@param column number
+    PositionItem = function(self, item, row, column)
+        BaseGridPanel.PositionItem(self, item, row, column)
+        local layouter = self.Layouter
+        layouter(item)
+            :Width(layouter:ScaleVar(self._columnWidth))
+            :Height(layouter:ScaleVar(self._rowHeight))
+            :DisableHitTest()
+    end,
+
+    ---@param self FactoryTemplatePreview
+    ---@param layouter ReUI.UI.Layouter
+    InitLayout = function(self, layouter)
+        BaseGridPanel.InitLayout(self, layouter)
+
+        layouter(self._title)
+            :Above(self, 2)
+            :Color(UIUtil.factionTextColor)
+            :DropShadow(true)
+            :DisableHitTest()
+
+        layouter(self)
+            :Depth(1000)
+            :DisableHitTest(true)
+    end,
+
+    ---@param self FactoryTemplatePreview
+    ---@param template table
+    DisplayTemplate = function(self, template)
+
+        self._title:SetText(template.name)
+
+        local data = template.templateData
+        local count = table.getn(data)
+
+        local columns = math.min(count, MAX_COLUMNS)
+        local rows = math.ceil(count / columns)
+
+        self.Rows = rows
+        self.Columns = columns
+
+        local i = 1
+        ---@param item FactoryTemplatePreview.Icon
+        self:IterateItemsVertically(function(grid, item, row, column)
+            local itemData = data[i]
+            if itemData then
+                item:Show()
+                item:Set(itemData)
+            else
+                item:Hide()
+            end
+            i = i + 1
+        end)
+
+    end,
+}

--- a/mods/ReUI.Construction.Templates/ModuleMeta.lua
+++ b/mods/ReUI.Construction.Templates/ModuleMeta.lua
@@ -1,0 +1,5 @@
+---@meta
+
+
+---@class ReUI.Construction.Templates : ReUI.Module
+ReUI.Construction.Templates = {}

--- a/mods/ReUI.Construction.Templates/Options.lua
+++ b/mods/ReUI.Construction.Templates/Options.lua
@@ -1,0 +1,18 @@
+local Options = ReUI.Options.Builder
+local Opt = ReUI.Options.Opt
+
+ReUI.Options.Mods["ReUI.Construction.Templates"] = {
+    templateNameLength = Opt(10),
+    previewBuildTemplates = Opt(true),
+    previewFactoryTemplates = Opt(true),
+}
+
+function Main()
+    local options = ReUI.Options.Mods["ReUI.Construction.Templates"]
+    Options.AddOptions("ReUI.Construction.Templates", "ReUI.Construction.Templates", {
+        Options.Slider("Templates name length", 1, 10, 1, options.templateNameLength, 4),
+        Options.Filter("Preview build templates", options.previewBuildTemplates, 4),
+        Options.Filter("Preview factory templates", options.previewFactoryTemplates, 4),
+    })
+
+end

--- a/mods/ReUI.Construction.Templates/Templates.lua
+++ b/mods/ReUI.Construction.Templates/Templates.lua
@@ -1,0 +1,570 @@
+ReUI.Require
+{
+    "ReUI.Core >= 1.0.0",
+    "ReUI.LINQ >= 1.4.0",
+    "ReUI.UI >= 1.4.0",
+    "ReUI.UI.Color >= 1.0.0",
+    "ReUI.UI.Animation >= 1.1.0",
+    "ReUI.UI.Controls >= 1.0.0",
+    "ReUI.UI.Views >= 1.2.0",
+    "ReUI.UI.Views.Grid >= 1.1.0",
+    "ReUI.Options >= 1.0.0",
+    "ReUI.Units >= 1.0.0",
+    "ReUI.Units.Enhancements >= 1.2.0",
+    "ReUI.Construction >= 1.0.0",
+}
+
+function Main()
+    local Templates = import("/lua/ui/game/build_templates.lua")
+    local FactoryTemplates = import("/lua/ui/templates_factory.lua")
+    local CommandMode = import("/lua/ui/game/commandmode.lua")
+    local UIUtil = import('/lua/ui/uiutil.lua')
+
+    local AItemComponent = ReUI.UI.Views.Grid.Abstract.AItemComponent
+    local ASelectionHandler = ReUI.UI.Views.Grid.Abstract.ASelectionHandler
+
+
+    local Enumerate = ReUI.LINQ.Enumerate
+    local IPairsEnumerator = ReUI.LINQ.IPairsEnumerator
+    local PairsEnumerator = ReUI.LINQ.PairsEnumerator
+
+    local ToSet = IPairsEnumerator:ToSet()
+    local Contains = IPairsEnumerator:Contains()
+
+    local FactoryTemplatePreview = import("FactoryTemplatePreview.lua").FactoryTemplatePreview
+    local BuildTemplatePreview = import("BuildTemplatePreview.lua").BuildTemplatePreview
+
+    local PREFIXES = {
+        ["aeon"]     = { "ua", "xa", "da", "za" },
+        ["uef"]      = { "ue", "xe", "de", "ze" },
+        ["cybran"]   = { "ur", "xr", "dr", "zr" },
+        ["seraphim"] = { "xs", "us", "ds", "zs" }
+    }
+
+    ---@param id string
+    ---@param buildableUnits table<string, true>
+    ---@return string|false
+    local function ConvertToBuildable(id, buildableUnits)
+        local suffix = string.sub(id, 3)
+        local pref = string.sub(id, 1, 2)
+
+        local i
+        for faction, prefixes in pairs(PREFIXES) do
+            i = Contains(prefixes, pref)
+            if i then
+                break
+            end
+        end
+        if not i then
+            return false
+        end
+
+        for faction, prefixes in pairs(PREFIXES) do
+            local prefix = prefixes[i]
+            local newId = prefix .. suffix
+            if buildableUnits[newId] then
+                return newId
+            end
+        end
+
+        return false
+    end
+
+    ---@param template any
+    ---@param buildableUnits any
+    local function ConvertBuildTemplate(template, buildableUnits)
+        template = table.deepcopy(template)
+        local templateData = template.templateData
+        for i = 3, table.getn(templateData) do
+            local entry = templateData[i]
+            local id = entry[1]
+            entry[1] = ConvertToBuildable(id, buildableUnits)
+        end
+        template.icon = ConvertToBuildable(template.icon, buildableUnits) or ""
+        return template
+    end
+
+    ---@param template any
+    ---@param buildableUnits any
+    ---@return boolean
+    local function CanBuildTemplate(template, buildableUnits)
+        local templateData = template.templateData
+        for i = 3, table.getn(templateData) do
+            local entry = templateData[i]
+            local id = entry[1]
+            if not ConvertToBuildable(id, buildableUnits) then
+                return false
+            end
+        end
+        return true
+    end
+
+    ---@param templates FactoryTemplateData[]
+    ---@param buildable table<string, true>
+    local function GetAvailableFactoryTemplates(templates, buildable)
+        local availableTemplates = {}
+        for _, template in ipairs(templates) do
+            local valid = true
+            for _, entry in ipairs(template.templateData) do
+                if not buildable[entry.id] then
+                    valid = false
+                    break
+                end
+            end
+            if valid then
+                table.insert(availableTemplates, template)
+            end
+        end
+        return availableTemplates
+    end
+
+    ---@param data FactoryTemplateData
+    local function IssueFactoryTemplate(data)
+        for _, entry in ipairs(data.templateData) do
+            IssueBlueprintCommand("UNITCOMMAND_BuildFactory", entry.id, entry.count)
+        end
+    end
+
+    local options = ReUI.Options.Mods["ReUI.Construction.Templates"]
+
+    local templateNameLength
+    options.templateNameLength:Bind(function(opt)
+        templateNameLength = opt()
+    end)
+
+    ---@class TemplateComponentBase : AItemComponent
+    ---@field name ReUI.UI.Controls.Text
+    ---@field data any
+    local TemplateComponentBase = ReUI.Core.Class(AItemComponent)
+    {
+        ---Called when component is bond to an item
+        ---@param self TemplateComponentBase
+        ---@param item ReUI.Construction.Grid.Item
+        Create = function(self, item)
+            self.name = ReUI.UI.Controls.Text(item)
+            self.name:SetFont("Arial", 11)
+            item.Layouter(self.name)
+                :AnchorToBottom(item, -3)
+                :AtHorizontalCenterIn(item)
+                :Color(UIUtil.factionTextColor)
+                :DropShadow(true)
+                :Over(item, 10)
+                :DisableHitTest()
+                :Hide()
+        end,
+
+        ---Called when item is activated with this component event handling
+        ---@param self TemplateComponentBase
+        ---@param item ReUI.Construction.Grid.Item
+        ---@param action any
+        ---@param context ConstructionContext
+        Enable = function(self, item, action, context)
+            self.data = action
+            local id = self.data.icon
+            item:DisplayBPID(id)
+            self.name:SetText(string.sub(self.data.name, 1, templateNameLength))
+            self.name:Show()
+        end,
+
+        ---Called when item is changing event handler
+        ---@param self TemplateComponentBase
+        ---@param item ReUI.Construction.Grid.Item
+        Disable = function(self, item)
+            self.name:Hide()
+            item:ClearDisplay()
+        end,
+
+        ---Called when component is being destroyed
+        ---@param self TemplateComponentBase
+        Destroy = function(self)
+            self.name:Destroy()
+            self.name = nil
+        end,
+    }
+
+    local function ClearBuildPreview()
+        local preview = ReUI.UI.Global["BuildTemplatePreview"]
+        if not IsDestroyed(preview) then
+            preview:Destroy()
+        end
+        ReUI.UI.Global["BuildTemplatePreview"] = nil
+    end
+
+    local function ClearFactoryPreview()
+        local preview = ReUI.UI.Global["FactoryTemplatePreview"]
+        if not IsDestroyed(preview) then
+            preview:Destroy()
+        end
+        ReUI.UI.Global["FactoryTemplatePreview"] = nil
+    end
+
+    ---@class BuildTemplatesHandler : ASelectionHandler
+    local BuildTemplatesHandler = ReUI.Core.Class(ASelectionHandler)
+    {
+        Name = "BuildTemplatesHandler",
+
+        ---@param self BuildTemplatesHandler
+        ---@param panel ReUI.Construction.Panel
+        OnInit = function(self, panel)
+        end,
+
+        ---@param self BuildTemplatesHandler
+        ---@param context ConstructionContext
+        ---@return string[]?
+        Update = function(self, context)
+            if context.tech ~= "BUILD_TEMPLATES" then
+                ClearBuildPreview()
+                return
+            end
+
+            local selection = context.selection
+            if table.empty(selection) then
+                return
+            end
+            ---@cast selection -nil
+
+            local isAllEngineers = table.empty(EntityCategoryFilterOut(categories.ENGINEER, selection))
+            if not isAllEngineers then
+                return
+            end
+
+            local _, _, builableCategories = GetUnitCommandData(selection)
+            local buildableUnits = EntityCategoryGetUnitList(builableCategories)
+            if table.empty(buildableUnits) then
+                return
+            end
+
+            local templates = Templates.GetTemplates()
+            if table.empty(templates) then
+                return {}
+            end
+
+            local buildableSet = ToSet(buildableUnits)
+
+            local items = {}
+            for _, template in templates do
+                if CanBuildTemplate(template, buildableSet) then
+                    table.insert(items, ConvertBuildTemplate(template, buildableSet))
+                end
+            end
+
+            return items
+        end,
+
+        ---@param self BuildTemplatesHandler
+        OnDestroy = function(self)
+        end,
+
+        ---@class BuildTemplateItem : TemplateComponentBase
+        ---@field name ReUI.UI.Controls.Text
+        ComponentClass = ReUI.Core.Class(TemplateComponentBase)
+        {
+            ---Called when grid item receives an event
+            ---@param self BuildTemplateItem
+            ---@param item ReUI.Construction.Grid.Item
+            ---@param event KeyEvent
+            HandleEvent = function(self, item, event)
+                if event.Type == "ButtonPress" or event.Type == "ButtonDClick" then
+                    ClearBuildTemplates()
+                    local cmd = self.data.templateData[3][1]
+                    CommandMode.StartCommandMode("build", { name = cmd })
+                    SetActiveBuildTemplate(self.data.templateData)
+                elseif event.Type == "MouseEnter" and options.previewBuildTemplates() then
+                    self:CreatePreview(item)
+                elseif event.Type == "MouseExit" then
+                    self:ClearPreview()
+                end
+            end,
+
+            ---@param self BuildTemplateItem
+            ClearPreview = function(self)
+                ClearBuildPreview()
+            end,
+
+            ---@param self BuildTemplateItem
+            ---@param item ReUI.Construction.Grid.Item
+            CreatePreview = function(self, item)
+                self:ClearPreview()
+                local preview = BuildTemplatePreview(item, self.data)
+                ReUI.UI.Global["BuildTemplatePreview"] = preview
+                preview:Layouter()
+                    :AnchorToTop(item, 10)
+                    :AtHorizontalCenterIn(item)
+            end,
+        },
+    }
+
+    ---@class FactoryTemplatesHandler : ASelectionHandler
+    ---@field panel ReUI.Construction.Panel
+    local FactoryTemplatesHandler = ReUI.Core.Class(ASelectionHandler)
+    {
+        Name = "FactoryTemplatesHandler",
+
+        ---@param self FactoryTemplatesHandler
+        ---@param panel ReUI.Construction.Panel
+        OnInit = function(self, panel)
+            -- self.panel = panel
+
+            -- ---@param panel ReUI.Construction.Panel
+            -- ---@param context ConstructionContext
+            -- panel.UpdateEvent:AddByKey(self.Name, function(panel, context)
+            --     if context.tab == "selection" or context.tab == "enhancements" then
+            --         return
+            --     end
+
+            --     LOG "here"
+            --     LOG(self.displayTemplates)
+
+            --     panel:SetAvailableTech {
+            --         ["BUILD_TEMPLATES"] = self.displayTemplates,
+            --     }
+            -- end)
+        end,
+
+        ---@param self FactoryTemplatesHandler
+        ---@param context ConstructionContext
+        ---@return string[]?
+        Update = function(self, context)
+            if context.tech ~= "BUILD_TEMPLATES" then
+                ClearFactoryPreview()
+                return
+            end
+
+            local selection = context.selection
+            if table.empty(selection) then
+                return
+            end
+            ---@cast selection -nil
+
+            local isAllFactories = table.empty(EntityCategoryFilterOut(categories.FACTORY, selection))
+            if not isAllFactories then
+                return
+            end
+
+            local _, _, builableCategories = GetUnitCommandData(selection)
+            local buildableUnits = EntityCategoryGetUnitList(builableCategories)
+            if table.empty(buildableUnits) then
+                return
+            end
+
+            local templates = FactoryTemplates.GetTemplates()
+            if table.empty(templates) then
+                return {}
+            end
+
+            local buildableSet = ToSet(buildableUnits)
+
+            local availableTemplates = GetAvailableFactoryTemplates(templates, buildableSet)
+
+            return availableTemplates
+        end,
+
+        ---@param self FactoryTemplatesHandler
+        OnDestroy = function(self)
+            -- self.panel.UpdateEvent:RemoveByKey(self.Name)
+        end,
+
+        ---@class FactoryTemplateItem : TemplateComponentBase
+        ComponentClass = ReUI.Core.Class(TemplateComponentBase)
+        {
+            ---Called when grid item receives an event
+            ---@param self FactoryTemplateItem
+            ---@param item ReUI.Construction.Grid.Item
+            ---@param event KeyEvent
+            HandleEvent = function(self, item, event)
+                if event.Type == "ButtonPress" or event.Type == "ButtonDClick" then
+                    if event.Modifiers.Left then
+                        IssueFactoryTemplate(self.data)
+                    end
+                    PlaySound(Sound({ Cue = "UI_MFD_Click", Bank = "Interface" }))
+                elseif event.Type == "MouseEnter" and options.previewFactoryTemplates() then
+                    self:CreatePreview(item)
+                elseif event.Type == "MouseExit" then
+                    self:ClearPreview()
+                end
+            end,
+
+            ---@param self FactoryTemplateItem
+            ClearPreview = function(self)
+                ClearFactoryPreview()
+            end,
+
+            ---@param self FactoryTemplateItem
+            ---@param item ReUI.Construction.Grid.Item
+            CreatePreview = function(self, item)
+                self:ClearPreview()
+                ---@type FactoryTemplatePreview
+                local preview = FactoryTemplatePreview(item)
+                preview:DisplayTemplate(self.data)
+                ReUI.UI.Global["FactoryTemplatePreview"] = preview
+                preview:Layouter()
+                    :Above(item, 30)
+            end,
+        },
+    }
+
+    ---@class BuildTemplateBehavior
+    local BuildTemplateBehavior = ReUI.Core.Class()
+    {
+        ---@param self BuildTemplateBehavior
+        ---@param checkBox ReUI.Construction.ActionCheckBox
+        OnAttach = function(self, checkBox)
+            checkBox:SetNewTextures(
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_up.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_selected.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_over.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_over.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_dis.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_dis.dds')
+            )
+
+            checkBox:SetOverlayTextures(
+                UIUtil.UIFile('/game/construct-sm_btn/template_off.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/template_on.dds')
+            )
+            checkBox:SetCheck(false, true)
+        end,
+
+        OnDetach = function(self, checkBox)
+        end,
+
+        ---@param self BuildTemplateBehavior
+        ---@param checkBox ReUI.Construction.ActionCheckBox
+        ---@param isChecked boolean
+        OnChecked = function(self, checkBox, isChecked)
+            Templates.CreateBuildTemplate()
+            print "Build template created"
+            checkBox:SetCheck(false, true)
+        end,
+
+        ---@param self BuildTemplateBehavior
+        ---@param checkBox ReUI.Construction.ActionCheckBox
+        OnUpdate = function(self, checkBox)
+            local context = checkBox.Context
+            local selection = context.selection
+
+            if table.empty(selection) then
+                checkBox:Disable()
+                return
+            end
+
+            local isAllStructures = table.empty(EntityCategoryFilterOut(categories.STRUCTURE, selection))
+            if not isAllStructures then
+                checkBox:Disable()
+                return
+            end
+
+            checkBox:Enable()
+        end,
+    }
+
+    ---@class FactoryTemplateBehavior
+    ---@field unit UserUnit?
+    local FactoryTemplateBehavior = ReUI.Core.Class()
+    {
+        ---@param self FactoryTemplateBehavior
+        ---@param checkBox ReUI.Construction.ActionCheckBox
+        OnAttach = function(self, checkBox)
+            checkBox:SetNewTextures(
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_up.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_selected.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_over.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_over.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_dis.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/mid_btn_dis.dds')
+            )
+
+            checkBox:SetOverlayTextures(
+                UIUtil.UIFile('/game/construct-sm_btn/template_off.dds'),
+                UIUtil.UIFile('/game/construct-sm_btn/template_on.dds')
+            )
+            checkBox:SetCheck(false, true)
+        end,
+
+        OnDetach = function(self, checkBox)
+        end,
+
+        ---@param self FactoryTemplateBehavior
+        ---@param checkBox ReUI.Construction.ActionCheckBox
+        ---@param isChecked boolean
+        OnChecked = function(self, checkBox, isChecked)
+            local unit = self.unit
+            if not unit then
+                return
+            end
+
+            ---@type UIBuildQueueItem[]
+            local currentCommandQueue
+            if EntityCategoryContains(categories.EXTERNALFACTORY, unit) then
+                currentCommandQueue = SetCurrentFactoryForQueueDisplay(unit:GetCreator()--[[@as UserUnit]] )
+            else
+                currentCommandQueue = SetCurrentFactoryForQueueDisplay(unit)
+            end
+
+            FactoryTemplates.CreateBuildTemplate(currentCommandQueue)
+
+            print "Factory template created"
+            checkBox:SetCheck(false, true)
+        end,
+
+        ---@param self FactoryTemplateBehavior
+        ---@param checkBox ReUI.Construction.ActionCheckBox
+        OnUpdate = function(self, checkBox)
+            checkBox:Disable()
+            self.unit = nil
+
+            local selection = checkBox.Context.selection
+            if table.empty(selection) then
+                return
+            end
+            ---@cast selection -nil
+            if table.getn(selection) ~= 1 then
+                return
+            end
+
+            local unit = selection[1]
+
+            if not EntityCategoryContains(categories.FACTORY + categories.EXTERNALFACTORY, unit) then
+                return
+            end
+
+            self.unit = unit
+            checkBox:Enable()
+        end,
+    }
+
+    ReUI.Construction.Panel.Actions["build_template"]   = BuildTemplateBehavior
+    ReUI.Construction.Panel.Actions["factory_template"] = FactoryTemplateBehavior
+
+    for _, handler in ReUI.Construction.Panel.PrimaryHandlers do
+        if handler.tab == "selection" then
+            handler.actions[1] = "build_template"
+        end
+    end
+
+    table.insert(ReUI.Construction.Panel.TechTabs,
+        {
+            name = "BUILD_TEMPLATES",
+            file = "/game/construct-tech_btn/template_btn_",
+        })
+
+    table.insert(ReUI.Construction.Panel.PrimaryHandlers,
+        1,
+        {
+            name = "BuildTemplates",
+            tab = "construction",
+            displayMode = "grid",
+            actions = { "repeatBuild", "pause" },
+            handler = BuildTemplatesHandler,
+        })
+
+    table.insert(ReUI.Construction.Panel.PrimaryHandlers,
+        1,
+        {
+            name = "FactoryTemplates",
+            tab = "construction",
+            displayMode = "grid",
+            actions = { "factory_template", "pause" },
+            handler = FactoryTemplatesHandler,
+        })
+end

--- a/mods/ReUI.Construction.Templates/Templates.lua
+++ b/mods/ReUI.Construction.Templates/Templates.lua
@@ -15,10 +15,11 @@ ReUI.Require
 }
 
 function Main()
-    local Templates = import("/lua/ui/game/build_templates.lua")
+    local Templates        = import("/lua/ui/game/build_templates.lua")
     local FactoryTemplates = import("/lua/ui/templates_factory.lua")
-    local CommandMode = import("/lua/ui/game/commandmode.lua")
-    local UIUtil = import('/lua/ui/uiutil.lua')
+    local CommandMode      = import("/lua/ui/game/commandmode.lua")
+    local UIUtil           = import('/lua/ui/uiutil.lua')
+    local Edit             = import("/lua/maui/edit.lua").Edit
 
     local AItemComponent = ReUI.UI.Views.Grid.Abstract.AItemComponent
     local ASelectionHandler = ReUI.UI.Views.Grid.Abstract.ASelectionHandler
@@ -27,6 +28,12 @@ function Main()
     local Enumerate = ReUI.LINQ.Enumerate
     local IPairsEnumerator = ReUI.LINQ.IPairsEnumerator
     local PairsEnumerator = ReUI.LINQ.PairsEnumerator
+
+
+    local Bitmap   = ReUI.UI.Controls.Bitmap
+    local Text     = ReUI.UI.Controls.Text
+    local CheckBox = ReUI.UI.Controls.CheckBox
+    local Group    = ReUI.UI.Controls.Group
 
     local ToSet = IPairsEnumerator:ToSet()
     local Contains = IPairsEnumerator:Contains()
@@ -103,7 +110,7 @@ function Main()
     ---@param buildable table<string, true>
     local function GetAvailableFactoryTemplates(templates, buildable)
         local availableTemplates = {}
-        for _, template in ipairs(templates) do
+        for i, template in ipairs(templates) do
             local valid = true
             for _, entry in ipairs(template.templateData) do
                 if not buildable[entry.id] then
@@ -112,7 +119,10 @@ function Main()
                 end
             end
             if valid then
-                table.insert(availableTemplates, template)
+                table.insert(availableTemplates, {
+                    index = i,
+                    template = template
+                })
             end
         end
         return availableTemplates
@@ -132,9 +142,13 @@ function Main()
         templateNameLength = opt()
     end)
 
+    ---@class TemplateData
+    ---@field template any
+    ---@field index integer
+
     ---@class TemplateComponentBase : AItemComponent
+    ---@field data TemplateData
     ---@field name ReUI.UI.Controls.Text
-    ---@field data any
     local TemplateComponentBase = ReUI.Core.Class(AItemComponent)
     {
         ---Called when component is bond to an item
@@ -156,13 +170,14 @@ function Main()
         ---Called when item is activated with this component event handling
         ---@param self TemplateComponentBase
         ---@param item ReUI.Construction.Grid.Item
-        ---@param action any
+        ---@param action TemplateData
         ---@param context ConstructionContext
         Enable = function(self, item, action, context)
             self.data = action
-            local id = self.data.icon
+            local template = action.template
+            local id = template.icon
             item:DisplayBPID(id)
-            self.name:SetText(string.sub(self.data.name, 1, templateNameLength))
+            self.name:SetText(string.sub(template.name, 1, templateNameLength))
             self.name:Show()
         end,
 
@@ -198,6 +213,169 @@ function Main()
         ReUI.UI.Global["FactoryTemplatePreview"] = nil
     end
 
+    ---@class BaseTemplateEditMenu : ReUI.UI.Controls.Group
+    ---@field item ReUI.Construction.Grid.Item
+    ---@field data TemplateData
+    ---@field _title ReUI.UI.Controls.Text
+    ---@field _edit Edit
+    ---@field _deleteBtn  Button
+    ---@field _closeBtn  Button
+    local BaseTemplateEditMenu = ReUI.Core.Class(Group)
+    {
+
+        ---@param self BaseTemplateEditMenu
+        __init = function(self, parent)
+            Group.__init(self, parent)
+
+            self.item = parent
+
+            self._title = Text(self)
+
+            self._edit = Edit(self)
+            self._edit.OnEnterPressed = function(edit, text)
+                self:OnNameChanged(text)
+                return true
+            end
+
+            self._deleteBtn = UIUtil.CreateButtonStd(self, '/widgets02/small', '<LOC _Delete>', 16)
+            self._deleteBtn.OnClick = function(btn, modifiers)
+                self:OnDelete()
+            end
+
+            self._closeBtn = UIUtil.CreateButtonStd(self, '/widgets02/small', '<LOC _Close>', 16)
+            self._closeBtn.OnClick = function(btn, modifiers)
+                self:Close()
+            end
+        end,
+
+        ---@param self BaseTemplateEditMenu
+        ---@param layouter ReUI.UI.Layouter
+        InitLayout = function(self, layouter)
+            layouter(self)
+                :AtCenterIn(self:GetRootFrame())
+                :Width(200)
+                :Height(150)
+                :Depth(self:GetRootFrame():GetTopmostDepth() + 1)
+
+            layouter(self._title)
+                :AtTopIn(self, 10)
+                :AtHorizontalCenterIn(self)
+                :Color(UIUtil.factionTextColor)
+            self._title:SetFont("Arial", 20)
+            self._title:SetText("Edit menu")
+
+
+            layouter(self._edit)
+                :Height(function() return self._edit:GetFontHeight() end)
+                :AtRightIn(self, 10)
+                :AtLeftIn(self, 10)
+                :AtTopIn(self, 35)
+            UIUtil.SetupEditStd(self._edit, "ffffffff", nil, "ffaaffaa", UIUtil.highlightColor, UIUtil.bodyFont, 16, 200)
+            self._edit:SetDropShadow(true)
+            self._edit:ShowBackground(true)
+            self._edit:SetText("")
+
+
+            layouter(self._closeBtn)
+                :AtBottomIn(self, 10)
+                :AtHorizontalCenterIn(self)
+
+            layouter(self._deleteBtn)
+                :AnchorToTop(self._closeBtn, 10)
+                :AtHorizontalCenterIn(self)
+
+            UIUtil.SurroundWithNinePatch(self, "/game/chat_brd/", 4, 4)
+        end,
+
+        ---@param self BaseTemplateEditMenu
+        ---@param data TemplateData
+        SetData = function(self, data)
+            self.data = data
+            self._edit:SetText(self.data.template.name)
+        end,
+
+        HandleEvent = function(self, event)
+            return true
+        end,
+
+        ---@param self BaseTemplateEditMenu
+        ---@param name string
+        OnNameChanged = function(self, name)
+        end,
+
+        ---@param self BaseTemplateEditMenu
+        OnDelete = function(self)
+        end,
+
+        ---@param self BaseTemplateEditMenu
+        Close = function(self)
+            self:OnClose()
+        end,
+
+        ---@param self BaseTemplateEditMenu
+        OnClose = function(self)
+            self:Destroy()
+        end,
+    }
+
+
+    ---@class BuildTemplateEditMenu : BaseTemplateEditMenu
+    local BuildTemplateEditMenu = ReUI.Core.Class(BaseTemplateEditMenu)
+    {
+        ---@param self BuildTemplateEditMenu
+        ---@param name string
+        OnNameChanged = function(self, name)
+            Templates.RenameTemplate(self.data.index, name)
+            self.item:UpdatePanel()
+        end,
+
+        ---@param self BuildTemplateEditMenu
+        OnDelete = function(self)
+            Templates.RemoveTemplate(self.data.index)
+            self.item:UpdatePanel()
+            self:Close()
+        end,
+    }
+
+
+    ---@class FactoryTemplateEditMenu : BaseTemplateEditMenu
+    local FactoryTemplateEditMenu = ReUI.Core.Class(BaseTemplateEditMenu)
+    {
+        ---@param self FactoryTemplateEditMenu
+        ---@param name string
+        OnNameChanged = function(self, name)
+            FactoryTemplates.RenameTemplate(self.data.index, name)
+            self.item:UpdatePanel()
+        end,
+
+        ---@param self FactoryTemplateEditMenu
+        OnDelete = function(self)
+            FactoryTemplates.RemoveTemplate(self.data.index)
+            self.item:UpdatePanel()
+            self:Close()
+        end,
+    }
+
+
+    ---@return BaseTemplateEditMenu
+    local function CreateEditMenu(class, item)
+        local menu = ReUI.UI.Global["ReUI.Construction.Templates.EditMenu"]
+        if not IsDestroyed(menu) then
+            menu:Destroy()
+        end
+        menu = class(item)
+        ReUI.UI.Global["ReUI.Construction.Templates.EditMenu"] = menu
+        return menu
+    end
+
+    local function CloseEditMenu()
+        local menu = ReUI.UI.Global["ReUI.Construction.Templates.EditMenu"]
+        if not IsDestroyed(menu) then
+            menu:Destroy()
+        end
+        ReUI.UI.Global["ReUI.Construction.Templates.EditMenu"] = nil
+    end
+
     ---@class BuildTemplatesHandler : ASelectionHandler
     local BuildTemplatesHandler = ReUI.Core.Class(ASelectionHandler)
     {
@@ -213,6 +391,7 @@ function Main()
         ---@return string[]?
         Update = function(self, context)
             if context.tech ~= "BUILD_TEMPLATES" then
+                CloseEditMenu()
                 ClearBuildPreview()
                 return
             end
@@ -242,9 +421,12 @@ function Main()
             local buildableSet = ToSet(buildableUnits)
 
             local items = {}
-            for _, template in templates do
+            for i, template in templates do
                 if CanBuildTemplate(template, buildableSet) then
-                    table.insert(items, ConvertBuildTemplate(template, buildableSet))
+                    table.insert(items, {
+                        index = i,
+                        template = ConvertBuildTemplate(template, buildableSet)
+                    })
                 end
             end
 
@@ -265,10 +447,15 @@ function Main()
             ---@param event KeyEvent
             HandleEvent = function(self, item, event)
                 if event.Type == "ButtonPress" or event.Type == "ButtonDClick" then
-                    ClearBuildTemplates()
-                    local cmd = self.data.templateData[3][1]
-                    CommandMode.StartCommandMode("build", { name = cmd })
-                    SetActiveBuildTemplate(self.data.templateData)
+                    if event.Modifiers.Left then
+                        ClearBuildTemplates()
+                        local cmd = self.data.template.templateData[3][1]
+                        CommandMode.StartCommandMode("build", { name = cmd })
+                        SetActiveBuildTemplate(self.data.template.templateData)
+                    elseif event.Modifiers.Right then
+                        CreateEditMenu(BuildTemplateEditMenu, item)
+                            :SetData(self.data)
+                    end
                 elseif event.Type == "MouseEnter" and options.previewBuildTemplates() then
                     self:CreatePreview(item)
                 elseif event.Type == "MouseExit" then
@@ -285,7 +472,7 @@ function Main()
             ---@param item ReUI.Construction.Grid.Item
             CreatePreview = function(self, item)
                 self:ClearPreview()
-                local preview = BuildTemplatePreview(item, self.data)
+                local preview = BuildTemplatePreview(item, self.data.template)
                 ReUI.UI.Global["BuildTemplatePreview"] = preview
                 preview:Layouter()
                     :AnchorToTop(item, 10)
@@ -303,22 +490,6 @@ function Main()
         ---@param self FactoryTemplatesHandler
         ---@param panel ReUI.Construction.Panel
         OnInit = function(self, panel)
-            -- self.panel = panel
-
-            -- ---@param panel ReUI.Construction.Panel
-            -- ---@param context ConstructionContext
-            -- panel.UpdateEvent:AddByKey(self.Name, function(panel, context)
-            --     if context.tab == "selection" or context.tab == "enhancements" then
-            --         return
-            --     end
-
-            --     LOG "here"
-            --     LOG(self.displayTemplates)
-
-            --     panel:SetAvailableTech {
-            --         ["BUILD_TEMPLATES"] = self.displayTemplates,
-            --     }
-            -- end)
         end,
 
         ---@param self FactoryTemplatesHandler
@@ -326,6 +497,7 @@ function Main()
         ---@return string[]?
         Update = function(self, context)
             if context.tech ~= "BUILD_TEMPLATES" then
+                CloseEditMenu()
                 ClearFactoryPreview()
                 return
             end
@@ -361,7 +533,6 @@ function Main()
 
         ---@param self FactoryTemplatesHandler
         OnDestroy = function(self)
-            -- self.panel.UpdateEvent:RemoveByKey(self.Name)
         end,
 
         ---@class FactoryTemplateItem : TemplateComponentBase
@@ -374,9 +545,12 @@ function Main()
             HandleEvent = function(self, item, event)
                 if event.Type == "ButtonPress" or event.Type == "ButtonDClick" then
                     if event.Modifiers.Left then
-                        IssueFactoryTemplate(self.data)
+                        IssueFactoryTemplate(self.data.template)
+                        PlaySound(Sound({ Cue = "UI_MFD_Click", Bank = "Interface" }))
+                    elseif event.Modifiers.Right then
+                        CreateEditMenu(FactoryTemplateEditMenu, item)
+                            :SetData(self.data)
                     end
-                    PlaySound(Sound({ Cue = "UI_MFD_Click", Bank = "Interface" }))
                 elseif event.Type == "MouseEnter" and options.previewFactoryTemplates() then
                     self:CreatePreview(item)
                 elseif event.Type == "MouseExit" then
@@ -395,7 +569,7 @@ function Main()
                 self:ClearPreview()
                 ---@type FactoryTemplatePreview
                 local preview = FactoryTemplatePreview(item)
-                preview:DisplayTemplate(self.data)
+                preview:DisplayTemplate(self.data.template)
                 ReUI.UI.Global["FactoryTemplatePreview"] = preview
                 preview:Layouter()
                     :Above(item, 30)

--- a/mods/ReUI.Construction.Templates/mod_info.lua
+++ b/mods/ReUI.Construction.Templates/mod_info.lua
@@ -1,0 +1,17 @@
+name = "ReUI.Construction.Templates"
+uid = "ReUI.Construction.Templates-1.0.0"
+version = 1
+copyright = ""
+description = [[Check on Github and official Discord server for mode details.
+https://github.com/4z0t/FAF-UI-Mods
+https://discord.gg/UZeAEXHV
+]]
+author = "4z0t"
+icon = "/mods/ReUI.Construction.Templates/icon.png"
+url = "https://github.com/4z0t/FAF-UI-Mods"
+selectable = true
+enabled = true
+exclusive = false
+ui_only = true
+
+ReUI = 'ReUI.Construction.Templates=1.0.0'


### PR DESCRIPTION
An extension mod for ReUI.Construction that adds templates tab into construction panel.
<img width="469" height="463" alt="image" src="https://github.com/user-attachments/assets/9caef6a4-5e5e-47f0-9802-2ab65482d7a3" />
<img width="510" height="240" alt="image" src="https://github.com/user-attachments/assets/8e8812d8-8d1a-48af-907f-1fcf96f93286" />
<img width="418" height="201" alt="image" src="https://github.com/user-attachments/assets/ea7c4833-f1da-4b4f-bebb-8ba42f93e7ba" />
It also serves as example of how to create extension mods for ReUI.Construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build Templates tab with titled previews, grid placement and quick-activate build actions
  * Factory Templates tab with titled icon grid, per-item counts and quick-production actions
  * Hover previews, left-click activation and right-click edit for templates
  * Templates filtered automatically to show only units you can build

* **Options**
  * New settings: template name length slider and toggles to enable/disable build/factory previews

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/4z0t/FAF-UI-Mods/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->