### PR TITLE
AKA: 1.2.1

### DIFF
--- a/mods/AKA/Main.lua
+++ b/mods/AKA/Main.lua
@@ -68,7 +68,7 @@ function Main()
         CategoryMatcher "Transportation / Overcharge / Repeat queue / Explode Fire Beetle"
             :Modifiers { shift = true }
             {
-                -- CategoryAction()
+                CategoryAction(), -- do nothing if no selection
                 --     :Action(Misc.AddNearestIdleEngineersSeq),
                 CategoryAction(categories.TRANSPORTATION)
                     :Action "StartCommandMode order RULEUCC_Transport",

--- a/mods/AKA/mod_info.lua
+++ b/mods/AKA/mod_info.lua
@@ -1,5 +1,5 @@
 name = "Advanced Key Actions"
-version = 3
+version = 4
 copyright = "MIT License"
 description = [[
 Adds these keybinds that combine multiple actions into one based on current selection:
@@ -17,9 +17,9 @@ Requires ReUI
 ]]
 author = "4z0t"
 url = "https://github.com/4z0t/FAF-UI-Mods"
-uid = "advanced-key-actions-1.2.0"
+uid = "advanced-key-actions-1.2.1"
 exclusive = false
 ui_only = true
 conflicts = {}
 
-ReUI = "AKA=1.2.0"
+ReUI = "AKA=1.2.1"


### PR DESCRIPTION
* fix crash caused by passing no selection into `GetUnitCommandData`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling for cases with no selection in the Transportation/Overcharge/Repeat queue/Explode Fire Beetle action category.

* **Chores**
  * Bumped mod version to 1.2.1 and updated related dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->