### PR TITLE
ReUI.Reclaim: 1.2.1

### DIFF
--- a/mods/ReUI.Reclaim/Options.lua
+++ b/mods/ReUI.Reclaim/Options.lua
@@ -3,13 +3,14 @@ local Opt = ReUI.Options.Opt
 
 
 ReUI.Options.Mods["ReUI.Reclaim"] = {
-    useBatching       = Opt(true),
-    maxLabels         = Opt(1000),
-    zoomThreshold     = Opt(150),
-    heightRatio       = Opt(12),
-    updateRate        = Opt(100),
-    scale             = Opt(100),
-    totalMassFontSize = Opt(14),
+    useBatching         = Opt(true),
+    displayMinimumValue = Opt(false),
+    maxLabels           = Opt(1000),
+    zoomThreshold       = Opt(150),
+    heightRatio         = Opt(12),
+    updateRate          = Opt(100),
+    scale               = Opt(100),
+    totalMassFontSize   = Opt(14),
 }
 
 function Main()
@@ -17,6 +18,7 @@ function Main()
     Options.AddOptions("ReUI.Reclaim", "ReUI.Reclaim", {
         Options.Slider("Scale", 50, 300, 25, options.scale, 4),
         Options.Filter("Use batching", options.useBatching, 4),
+        Options.Filter("Display minimum reclaim value (10)", options.displayMinimumValue, 4),
         Options.Slider("Max labels", 100, 10000, 100, options.maxLabels, 4),
         Options.Slider("Zoom threshold", 150, 600, 10, options.zoomThreshold, 4),
         Options.Slider("Grouping distance", 5, 20, 1, options.heightRatio, 4),

--- a/mods/ReUI.Reclaim/Reclaim.lua
+++ b/mods/ReUI.Reclaim/Reclaim.lua
@@ -158,7 +158,7 @@ function Main(isReplay)
     ---@param maxMass number
     ---@return string?
     ---@return integer?
-    local function ComputeLabelPropertiesBatched(totalMass, maxMass)
+    local function GetLabelPropsClear(totalMass, maxMass)
         if totalMass <= 10 then return nil, nil end
         if maxMass < 100 then return 'ffc7ff8f', 10 end
         if maxMass < 300 then return 'ffd7ff05', 12 end
@@ -168,7 +168,31 @@ function Main(isReplay)
         return 'fffb0303', 25
     end
 
+    ---@param totalMass number
+    ---@param maxMass number
+    ---@return string?
+    ---@return integer?
+    local function GetLabelPropsFull(totalMass, maxMass)
+        if maxMass < 100 then return 'ffc7ff8f', 10 end
+        if maxMass < 300 then return 'ffd7ff05', 12 end
+        if maxMass < 600 then return 'ffffeb23', 17 end
+        if maxMass < 1000 then return 'ffff9d23', 20 end
+        if maxMass < 2000 then return 'ffff7212', 22 end
+        return 'fffb0303', 25
+    end
+
     local options = ReUI.Options.Mods["ReUI.Reclaim"]
+
+    ---@type fun(totalMass: number, maxMass: number) : string?, integer?
+    local GetLabelColorAndSize = GetLabelPropsClear
+
+    options.displayMinimumValue:Bind(function(opt)
+        if opt() then
+            GetLabelColorAndSize = GetLabelPropsFull
+        else
+            GetLabelColorAndSize = GetLabelPropsClear
+        end
+    end)
 
     ---@type number
     local heightRatio
@@ -246,7 +270,7 @@ function Main(isReplay)
 
         ---@param self ReclaimLabel
         AdjustToValue = function(self, total, max)
-            local color, size = ComputeLabelPropertiesBatched(total, max or total)
+            local color, size = GetLabelColorAndSize(total, max or total)
             if color then
                 self.text:SetFont(UIUtil.bodyFont, size * iconScale) -- r.mass > 2000
                 self.text:SetColor(color)

--- a/mods/ReUI.Reclaim/mod_info.lua
+++ b/mods/ReUI.Reclaim/mod_info.lua
@@ -1,6 +1,6 @@
 name = "ReUI.Reclaim"
-uid = "reui-reclaim-1.2.0"
-version = 6
+uid = "reui-reclaim-1.2.1"
+version = 7
 copyright = ""
 description = [[Check on Github and official Discord server for mode details.
 https://github.com/4z0t/FAF-UI-Mods
@@ -19,4 +19,4 @@ conflicts = {}
 before = {}
 after = {}
 
-ReUI = 'ReUI.Reclaim=1.2.0'
+ReUI = 'ReUI.Reclaim=1.2.1'


### PR DESCRIPTION
* add option to display minimum reclaim value
<img width="640" height="474" alt="image" src="https://github.com/user-attachments/assets/75e50be5-31fc-4cbd-b710-3cb060166e99" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to toggle display of minimum reclaim values. When enabled, reclaim value labels display for all amounts; when disabled (default), labels remain hidden for low-value reclaim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->