### PR TITLE
ReUI.Score: 1.2.4

### DIFF
--- a/mods/ReUI.Score/Main.lua
+++ b/mods/ReUI.Score/Main.lua
@@ -306,6 +306,19 @@ function Main(isReplay)
         end
     end)
 
+    AddOnSyncHashedCallback(
+        function()
+            local scoreboard = ReUI.UI.Global["ScoreBoard"]
+            if _IsDestroyed(scoreboard) then
+                return
+            end
+
+            scoreboard:FocusArmyChanged()
+        end,
+        "FocusArmyChanged",
+        "ReUI.Score:FocusArmyChanged"
+    )
+
     ReUI.Core.OnPostCreateUI(function(isReplay)
         import('/lua/ui/game/score.lua').CreateScoreUI()
     end)

--- a/mods/ReUI.Score/Modules/ArmyView.lua
+++ b/mods/ReUI.Score/Modules/ArmyView.lua
@@ -509,7 +509,7 @@ AllyView = ReUI.Core.Class(ArmyView)
         end
         self._unitsBtn.HandleEvent = function(control, event)
             if event.Type == "ButtonPress" then
-                if event.Modifiers.Left then
+                if not event.Modifiers.shift then
                     ShareManager.GiveUnitsToPlayer(self.id)
                 elseif event.Modifiers.Right then
                     ShareManager.RequestUnitFromPlayer(self.id)

--- a/mods/ReUI.Score/Modules/ArmyView.lua
+++ b/mods/ReUI.Score/Modules/ArmyView.lua
@@ -544,6 +544,7 @@ AllyView = ReUI.Core.Class(ArmyView)
             "",
             [[By left click gives selected units to this ally.
         By right click requests engineer from this ally.
+        By shift+left click changes Union Control to this ally.
         ]]   ,
             0.5
         )

--- a/mods/ReUI.Score/Modules/ArmyView.lua
+++ b/mods/ReUI.Score/Modules/ArmyView.lua
@@ -509,12 +509,14 @@ AllyView = ReUI.Core.Class(ArmyView)
         end
         self._unitsBtn.HandleEvent = function(control, event)
             if event.Type == "ButtonPress" then
-                if not event.Modifiers.shift then
-                    ShareManager.GiveUnitsToPlayer(self.id)
-                elseif event.Modifiers.Right then
+                if event.Modifiers.Left then
+                    if event.Modifiers.Shift then
+                        ConExecute('SetFocusArmy ' .. tostring(self.id - 1))
+                    else
+                        ShareManager.GiveUnitsToPlayer(self.id)
+                    end
+                elseif event.Modifiers.right then
                     ShareManager.RequestUnitFromPlayer(self.id)
-                elseif event.Modifiers.Shift then
-                    ConExecute('SetFocusArmy ' .. tostring(self.id - 1))
                 else
                 end
                 return true

--- a/mods/ReUI.Score/Modules/ArmyView.lua
+++ b/mods/ReUI.Score/Modules/ArmyView.lua
@@ -513,6 +513,8 @@ AllyView = ReUI.Core.Class(ArmyView)
                     ShareManager.GiveUnitsToPlayer(self.id)
                 elseif event.Modifiers.Right then
                     ShareManager.RequestUnitFromPlayer(self.id)
+                elseif event.Modifiers.Shift then
+                    ConExecute('SetFocusArmy ' .. tostring(self.id - 1))
                 else
                 end
                 return true

--- a/mods/ReUI.Score/Modules/ArmyView.lua
+++ b/mods/ReUI.Score/Modules/ArmyView.lua
@@ -515,7 +515,7 @@ AllyView = ReUI.Core.Class(ArmyView)
                     else
                         ShareManager.GiveUnitsToPlayer(self.id)
                     end
-                elseif event.Modifiers.right then
+                elseif event.Modifiers.Right then
                     ShareManager.RequestUnitFromPlayer(self.id)
                 else
                 end

--- a/mods/ReUI.Score/Modules/ScoreBoard.lua
+++ b/mods/ReUI.Score/Modules/ScoreBoard.lua
@@ -229,6 +229,12 @@ ScoreBoard = ReUI.Core.Class(Group)
         end
     end,
 
+    ---@param self ReUI.Score.ScoreBoard
+    FocusArmyChanged = function(self)
+        self:ApplyToViews(function(armyId, view)
+            view:ResetFont()
+        end)
+    end,
 
     GameSpeed = ReUI.Core.Property
     {
@@ -346,6 +352,13 @@ ReplayScoreBoard = ReUI.Core.Class(ScoreBoard)
             :DisableHitTest()
     end,
 
+    ---@param self ReUI.Score.ScoreBoard
+    FocusArmyChanged = function(self)
+        ScoreBoard.ApplyToViews(self, function(armyId, view)
+            view:ResetFont()
+        end)
+    end,
+
     GameSpeed = ReUI.Core.Property
     {
         get = function(self)
@@ -356,18 +369,11 @@ ReplayScoreBoard = ReUI.Core.Class(ScoreBoard)
         end
     },
 
-
     ---@param self ReUI.Score.ReplayScoreBoard
     ---@param data any
     UpdateArmiesData = function(self, data)
         self._armiesContainer:Update(data)
         self._teamsContainer:Update(data)
-        if self._focusArmy ~= GetFocusArmy() then
-            self._focusArmy = GetFocusArmy()
-            ScoreBoard.ApplyToViews(self, function(id, view)
-                view:ResetFont()
-            end)
-        end
     end,
 
     SortArmies = function(self, func, direction)

--- a/mods/ReUI.Score/mod_info.lua
+++ b/mods/ReUI.Score/mod_info.lua
@@ -3,7 +3,7 @@ uid = "reui-score-1.2.4"
 version = 5
 copyright = ""
 description = [[Thanks HotCheese for adding Union Control Support
-Check on Github and official Discord server for mode details.
+Check on Github and official Discord server for more details.
 https://github.com/4z0t/FAF-UI-Mods
 https://discord.gg/EZb6h6gbWz
 ]]

--- a/mods/ReUI.Score/mod_info.lua
+++ b/mods/ReUI.Score/mod_info.lua
@@ -1,8 +1,9 @@
 name = "ReUI.Score"
-uid = "reui-score-1.2.3"
-version = 4
+uid = "reui-score-1.2.4"
+version = 5
 copyright = ""
-description = [[Check on Github and official Discord server for mode details.
+description = [[Thanks HotCheese for adding Union Control Support
+Check on Github and official Discord server for mode details.
 https://github.com/4z0t/FAF-UI-Mods
 https://discord.gg/EZb6h6gbWz
 ]]
@@ -14,4 +15,4 @@ enabled = true
 exclusive = false
 ui_only = true
 
-ReUI = 'ReUI.Score=1.2.3'
+ReUI = 'ReUI.Score=1.2.4'

--- a/mods/ReUI.Score/mod_info.lua
+++ b/mods/ReUI.Score/mod_info.lua
@@ -2,12 +2,11 @@ name = "ReUI.Score"
 uid = "reui-score-1.2.4"
 version = 5
 copyright = ""
-description = [[Thanks HotCheese for adding Union Control Support
-Check on Github and official Discord server for more details.
+description = [[Check on Github and official Discord server for more details.
 https://github.com/4z0t/FAF-UI-Mods
 https://discord.gg/EZb6h6gbWz
 ]]
-author = "4z0t"
+author = "4z0t, HotCheese"
 icon = "/mods/ReUI.Score/icon.png"
 url = ""
 selectable = true


### PR DESCRIPTION
Added Shift+Left Click support on the unit icon to toggle army focus. For union control.

https://github.com/user-attachments/assets/5b8a52f0-209d-4e83-80f8-98dcd4859931





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift+left-click on an ally's units button now changes Union Control focus to that ally; tooltip updated to explain this.
  * Scoreboard UI now refreshes focus-related display after sync events so focus changes are reflected promptly.

* **Chores**
  * Mod metadata updated (version and author info).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->