### PR TITLE
AKA: 1.2.2

### DIFF
--- a/mods/AKA/Main.lua
+++ b/mods/AKA/Main.lua
@@ -51,6 +51,41 @@ function Main()
             end
         end
 
+        ---@param selection UserUnit[]?
+        local function TogglePause(selection)
+            if table.empty(selection) then
+                return
+            end
+            ---@cast selection -nil
+
+            local paused = not GetIsPaused(selection)
+            SetPaused(selection, paused)
+            local checkedS = paused and "true" or "false"
+            -- If we have exFacs platforms or exFac units selected, we'll pause their counterparts as well
+            for _, exFac in EntityCategoryFilterDown(categories.EXTERNALFACTORY +
+                categories.EXTERNALFACTORYUNIT,
+                selection) do
+                exFac:GetCreator():ProcessInfo('SetPaused', checkedS)
+            end
+        end
+
+        local ReConstruction = ReUI.Exists "ReUI.Construction >= 1.2.0" --[[@as ReUI.Construction?]]
+        if ReConstruction then
+            CategoryMatcher "Pause / Append unit for transportation"
+                :Modifiers { shift = true }
+                {
+                    CategoryAction(categories.TRANSPORTATION)
+                        :Action(function(selection)
+                            ReUI.Actions.ProcessAction "reui_construction_append_transport_cargo"
+                        end),
+                    CategoryAction()
+                        :Match(function(selection, category)
+                            return true
+                        end)
+                        :Action(TogglePause),
+                }
+        end
+
         CategoryMatcher "Transportation / Overcharge / Repeat queue"
             :Modifiers { shift = true }
             {

--- a/mods/AKA/mod_info.lua
+++ b/mods/AKA/mod_info.lua
@@ -1,5 +1,5 @@
 name = "Advanced Key Actions"
-version = 4
+version = 5
 copyright = "MIT License"
 description = [[
 Adds these keybinds that combine multiple actions into one based on current selection:
@@ -11,15 +11,16 @@ Adds these keybinds that combine multiple actions into one based on current sele
 * Select nearest air scout / build sensors
 * Zoom out / Soft stop / Hard stop
 * Zoom out / Hard stop
+* Pause / Append unit for transportation
 
 Can be found at ReUI.Actions section.
 Requires ReUI
 ]]
 author = "4z0t"
 url = "https://github.com/4z0t/FAF-UI-Mods"
-uid = "advanced-key-actions-1.2.1"
+uid = "advanced-key-actions-1.2.2"
 exclusive = false
 ui_only = true
 conflicts = {}
 
-ReUI = "AKA=1.2.1"
+ReUI = "AKA=1.2.2"


### PR DESCRIPTION
add `Pause / Append unit for transportation` action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pause/unpause controls for selected units.
  * New "Pause / Append unit for transportation" command category to streamline unit management (requires ReUI Construction 1.2.0+).

* **Updates**
  * Version bumped to 1.2.2 with improved ReUI compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->