### PR TITLE
RFA: update rings

### DIFF
--- a/mods/RFA/RFA.lua
+++ b/mods/RFA/RFA.lua
@@ -27,6 +27,14 @@ function Main(isReplay)
 
     local options = ReUI.Options.Mods["RFA"]
 
+    ---@param key string
+    local function IsPreviewKeyDown(key)
+        if key == "EITHER" then
+            return IsKeyDown("Shift") or IsKeyDown("Control")
+        end
+        return IsKeyDown(key)
+    end
+
     local Enumerate = ReUI.LINQ.Enumerate
     local IPairsEnumerator = ReUI.LINQ.IPairsEnumerator
     local PairsEnumerator = ReUI.LINQ.PairsEnumerator
@@ -797,14 +805,14 @@ function Main(isReplay)
             local notIssuingOrder = not commandMode[2]
             self._isCachedSelection = false
 
-            if IsKeyDown(self.HoverPreviewKey) and notIssuingOrder then
+            if IsPreviewKeyDown(self.HoverPreviewKey) and notIssuingOrder then
                 self:UpdateHoverRings()
             else
                 self:ClearHoverRings()
             end
 
             if notIssuingOrder or givingMoveOrder then
-                if IsKeyDown(self.SelectedPreviewKey) then
+                if IsPreviewKeyDown(self.SelectedPreviewKey) then
                     self:UpdateSelectionRings()
                 else
                     self:ClearSelectionRings()
@@ -812,7 +820,7 @@ function Main(isReplay)
 
                 if IsKeyDown(18) then --alt
                     self:UpdateReclaimRings()
-                elseif IsKeyDown(self.BuildPreviewKey) then
+                elseif IsPreviewKeyDown(self.BuildPreviewKey) then
                     self:UpdateBuildRings(true)
                 else
                     self:ClearBuildRings()

--- a/mods/RFA/mod_info.lua
+++ b/mods/RFA/mod_info.lua
@@ -1,13 +1,13 @@
 name = "Rings For All"
-uid = "rings-for-all-v1.0.0"
-version = 6
+uid = "rings-for-all-v1.1.0"
+version = 7
 copyright = ""
 description = [[
 Shows radiuses of weapons of selected units and build range. Also shows them with unit under mouse.
 See options for mod in ReUI.Options menu!
 
 ]]
-author = "4z0t, Nomander"
+author = "4z0t, Nomander, HotCheese"
 icon = "/mods/RFA/icon.png"
 url = ""
 selectable = true
@@ -20,4 +20,4 @@ conflicts = {}
 before = {}
 after = {}
 
-ReUI = 'RFA=1.0.0'
+ReUI = 'RFA=1.1.0'

--- a/mods/RFA/options.lua
+++ b/mods/RFA/options.lua
@@ -24,13 +24,15 @@ function Main()
             Options.Strings("Hover Preview key",
                 {
                     "SHIFT",
-                    "CONTROL"
+                    "CONTROL",
+                    "EITHER"
                 },
                 options.hoverPreviewKey),
             Options.Strings("Selected Preview key",
                 {
                     "SHIFT",
-                    "CONTROL"
+                    "CONTROL",
+                    "EITHER"
                 },
                 options.selectedPreviewKey),
             Options.Filter("Show range rings in minimap", options.showInMinimap, 4),
@@ -47,7 +49,8 @@ function Main()
             Options.Strings("Build Preview key",
                 {
                     "SHIFT",
-                    "CONTROL"
+                    "CONTROL",
+                    "EITHER"
                 },
                 options.buildPreviewKey),
         })


### PR DESCRIPTION
https://github.com/user-attachments/assets/c7337f20-72d4-4776-9ca5-204b151854bb

Added support for using both/either shift and ctrl for as preview keys. 

Useful for combining with your ctrl mod, to move gunships and keep them in range. While maintaining shift functionality 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Either” key binding options for hover, selected, and build previews.
  * “Either” activates previews when either Shift or Control is pressed.

* **Bug Fixes**
  * Updated preview behavior to correctly respond to the new key binding option.

* **Chores**
  * Updated the mod version and contributor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->