### PR TITLE
added select all direct fire land experimental/interrupt pathfinding

### DIFF
--- a/mods/AKA/Main.lua
+++ b/mods/AKA/Main.lua
@@ -17,6 +17,7 @@ function Main()
         local CM     = import("/lua/ui/game/commandmode.lua")
         local Misc   = import("/lua/keymap/misckeyactions.lua")
         local Orders = import("/lua/ui/game/orders.lua")
+        local Smart  = import("/lua/keymap/smartselection.lua")
 
         local attackMoveModeData = {
             name        = "RULEUCC_Script",

--- a/mods/AKA/Main.lua
+++ b/mods/AKA/Main.lua
@@ -172,6 +172,17 @@ function Main()
                     end)
                     :Action "StartCommandMode order RULEUCC_Move",
             }
+        CategoryMatcher "select All Direct Fire Land Experimentals/Interrupt Pathfinding"
+            :Modifiers { shift = true }
+            {
+                CategoryAction(categories.ENGINEER - categories.COMMAND)
+                    :Action(function() Misc.AbortNavigation() end),
+                CategoryAction()
+                    :Match(function(selection, category)
+                        return true
+                    end)
+                    :Action(function() Smart.smartSelect("MOBILE LAND EXPERIMENTAL DIRECTFIRE -SNIPER -ARTILLERY") end),
+            }
 
         local BuildSensorsF
         if Hotbuild then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shift-modified command to select mobile land experimentals with direct-fire weapons while excluding sniper and artillery units.
  * Automatically interrupts navigation for applicable engineer units when the command is triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->