### PR TITLE
Separate idle Builder support and added get current tech tab function

### DIFF
--- a/mods/ReUI.Construction/Construction.lua
+++ b/mods/ReUI.Construction/Construction.lua
@@ -66,6 +66,7 @@ function Main(isReplay)
     ---| "TECH2"
     ---| "TECH3"
     ---| "EXPERIMENTAL"
+    ---| "TEMPLATES"
 
     ---@class ConstructionHandlerData
     ---@field tab TabNames
@@ -718,6 +719,7 @@ function Main(isReplay)
     ---@class TechTabs : ReUI.UI.Controls.Group
     ---@field _constructionPanel ReUI.Construction.Panel
     ---@field _tabs ReUI.UI.Controls.CheckBox[]
+    ---@field _activeTech TechLevel
     local TechTabs = ReUI.Core.Class(Group)
     {
         AutoLayout = false,
@@ -729,6 +731,7 @@ function Main(isReplay)
             Group.__init(self, parent)
 
             self._constructionPanel = parent
+            self._activeTech = "NONE"
 
             ---@param tab TechTab
             ---@param checked boolean
@@ -747,10 +750,25 @@ function Main(isReplay)
         ---@param self TechTabs
         ---@param tech TechLevel
         SetActiveTechTab = function(self, tech)
+            self._activeTech = tech
             ---@param tab TechTab
             for i, tab in self._tabs do
                 tab:SetCheck(tab.name == tech, true)
             end
+        end,
+
+        ---@param self TechTabs
+        ---@return 1|2|3|4|5
+        GetCurrentTechTab = function(self)
+            local techTabs = {
+                TECH1 = 1,
+                TECH2 = 2,
+                TECH3 = 3,
+                EXPERIMENTAL = 4,
+                TEMPLATES = 5,
+            }
+
+            return techTabs[self._activeTech] or 5
         end,
 
         ---@param self TechTabs
@@ -807,6 +825,7 @@ function Main(isReplay)
         ---@param self TechTabs
         ---@param name string
         OnTabCheck = function(self, name)
+            self._activeTech = name
             ---@param tab TechTab
             for _, tab in self._tabs do
                 if tab.name ~= name then
@@ -1138,6 +1157,13 @@ function Main(isReplay)
             self._techTabs:SetActiveTechTab(tech)
         end,
 
+        ---Returns the selected construction tab: T1, T2, T3, T4, or templates.
+        ---@param self ReUI.Construction.Panel
+        ---@return 1|2|3|4|5
+        GetCurrentTechTab = function(self)
+            return self._techTabs:GetCurrentTechTab()
+        end,
+
         ---@param self ReUI.Construction.Panel
         ---@param func fun(self: ReUI.Construction.Panel, slot:ReUI.UI.Controls.CheckBox)
         ApplyToSlots = function(self, func)
@@ -1375,6 +1401,18 @@ function Main(isReplay)
 
 
     local ConstructionHook = ReUI.Core.HookModule "/lua/ui/game/construction.lua"
+
+    ConstructionHook("GetCurrentTechTab", function(field, module)
+        return function()
+            ---@type ReUI.Construction.Panel
+            local panel = ReUI.UI.Global["Construction"]
+            if not panel or IsDestroyed(panel) then
+                return 5
+            end
+
+            return panel:GetCurrentTechTab()
+        end
+    end)
 
     ConstructionHook("OnQueueChanged", function(field, module)
         return function(newQueue)

--- a/mods/ReUI.Construction/Modules/Components/SelectedUnits.lua
+++ b/mods/ReUI.Construction/Modules/Components/SelectedUnits.lua
@@ -148,6 +148,29 @@ AirFuelGroupMatcher = Class(UnitGroupMatcher)
     end,
 }
 
+---@class IdleConstructionGroupMatcher : UnitGroupMatcher
+IdleConstructionGroupMatcher = Class(UnitGroupMatcher)
+{
+    ---@param self IdleConstructionGroupMatcher
+    ---@param unit UserUnit
+    ---@return boolean
+    Match = function(self, unit)
+        if not EntityCategoryContains(categories.CONSTRUCTION, unit) then
+            return false
+        end
+        return unit:IsIdle()
+    end,
+
+    ---@param self IdleConstructionGroupMatcher
+    ---@param component SelectedUnitsListItem
+    ---@param item ReUI.Construction.Grid.Item
+    ---@param action SelectedUnitsAction
+    Display = function(self, component, item, action)
+        component.icon:SetTexture(UIUtil.UIFile('/game/idle_mini_icon/idle_icon.dds'))
+        component.icon:Show()
+    end,
+}
+
 ---@param name string
 ---@return FileName
 local function IconPath(name)
@@ -197,6 +220,7 @@ SelectedUnitsListHandler = ReUI.Core.Class(ASelectionHandler)
         CategoryGroupMatcher("STRUCTURE", IconPath "structure_generic", categories.STRUCTURE),
         CategoryGroupMatcher("CONSTRUCTION", IconPath "factory_generic", categories.SORTCONSTRUCTION),
         AirFuelGroupMatcher("LOWFUEL", '/game/unit_view_icons/fuel.dds'),
+        IdleConstructionGroupMatcher("IDLECONSTRUCTION", '/game/idle_mini_icon/idle_icon.dds'),
     },
 
     ---@param self SelectedUnitsListHandler


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Templates technology tab to the construction interface.
  * Added support for identifying the currently selected technology tab.
  * Added grouping for idle construction units, displayed with an idle indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->