### PR TITLE
added jamming toggle support for nearest idle engineer, reclaim, togg…

### DIFF
--- a/mods/AKA/Main.lua
+++ b/mods/AKA/Main.lua
@@ -140,7 +140,7 @@ function Main()
                     :Action 'StartCommandMode order RULEUCC_Attack',
             }
 
-        CategoryMatcher "Select nearest idle t1 engineer / reclaim / toggle shields / toggle stealth"
+        CategoryMatcher "Select nearest idle t1 engineer / reclaim / toggle shields / toggle stealth / toggle jamming"
             :Modifiers { shift = true }
             {
                 CategoryAction()
@@ -153,6 +153,12 @@ function Main()
                         return Contains(toggles, "RULEUTC_ShieldToggle")
                     end)
                     :Action(function() Misc.toggleScript "Shield" end),
+                CategoryAction()
+                    :Match(function(selection)
+                        local orders, toggles, _ = GetUnitCommandData(selection)
+                        return Contains(toggles, "RULEUTC_JammingToggle")
+                    end)
+                    :Action(function() Misc.toggleScript "Jamming" end),
                 CategoryAction()
                     :Match(function(selection)
                         local orders, toggles, _ = GetUnitCommandData(selection)


### PR DESCRIPTION
…le shields toggle, stealth

For Sparky and UEF Jammer SACUS, reclaim takes priority and jamming will not be toggled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added jamming toggle support to shift-action commands for engineers and reclaim units.
  * Jamming can now be enabled or disabled through the appropriate toggle action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->